### PR TITLE
Add TF 0.15.x to github action

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1.3.2
         with:
-          terraform_version: 0.13.6
+          terraform_version: 0.15.x
 
       - name: Terraform fmt
         id: fmt
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        terraform_version: [0.12.26, 0.13.6, 0.14.5]
+        terraform_version: [0.12.x, 0.13.x, 0.14.x, 0.15.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/examples/vault_eks_service_account/main.tf
+++ b/examples/vault_eks_service_account/main.tf
@@ -41,7 +41,7 @@ locals {
   issuerUrl = data.aws_eks_cluster.cluster.identity.0.oidc.0.issuer
 }
 
-data aws_iam_policy_document "base_policy" {
+data "aws_iam_policy_document" "base_policy" {
   statement {
     actions = [
       "sts:GetCallerIdentity"


### PR DESCRIPTION
## Changes
* Use the latest patch version of each Terraform release in the CI checks
* Add 0.15.x to the list of TF versions used in the CI checks
* tf fmt this file to fix formatting: `examples/vault_eks_service_account/main.tf`