### PR TITLE
Allow for just rendering the policy, and policy tweaks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                       @sijie @addisonj @withernet
+*                       @sijie @addisonj @jrsdav

--- a/examples/bootstrap_policies/main.tf
+++ b/examples/bootstrap_policies/main.tf
@@ -14,3 +14,14 @@ module "boostrap_full" {
   allow_eks_management = true
   allow_iam_management = true
 }
+
+# useful if you just want to render the policy and directly apply to another role
+module "boostrap_full_render_only" {
+  source      = "../../modules/bootstrap_policy"
+  policy_name = "streamnative-mc-bootstrap-full"
+
+  allow_eks_management = true
+  allow_iam_management = true
+
+  create_policy = false
+}

--- a/examples/bootstrap_policies/main.tf
+++ b/examples/bootstrap_policies/main.tf
@@ -16,7 +16,7 @@ module "boostrap_full" {
 }
 
 # useful if you just want to render the policy and directly apply to another role
-module "boostrap_full_render_only" {
+module "bootstrap_full_render_only" {
   source      = "../../modules/bootstrap_policy"
   policy_name = "streamnative-mc-bootstrap-full"
 

--- a/modules/management_policy/main.tf
+++ b/modules/management_policy/main.tf
@@ -59,6 +59,12 @@ variable "allow_asg_management" {
   default     = true
 }
 
+variable "create_policy" {
+  description = "actually create the policy, otherwise just render the policy"
+  type        = bool
+  default     = true
+}
+
 
 data "aws_caller_identity" "current" {}
 
@@ -141,19 +147,20 @@ module "policy_agg" {
 }
 
 resource "aws_iam_policy" "policy" {
-  name = var.policy_name
+  name  = var.policy_name
+  count = var.create_policy ? 1 : 0
 
   policy = module.policy_agg.result_document
 }
 
 
 output "policy_name" {
-  value       = aws_iam_policy.policy.name
+  value       = join("", aws_iam_policy.policy.*.name)
   description = "the name of the policy"
 }
 
 output "policy_arn" {
-  value       = aws_iam_policy.policy.arn
+  value       = join("", aws_iam_policy.policy.*.arn)
   description = "the arn of the policy"
 }
 


### PR DESCRIPTION
To make the policy modules more flexible, allow for just rendering.

This also does a few small tweaks to the policy to gran more permissions
for resources in bootstrap